### PR TITLE
feat: remove driving mode restrictions

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="aa_app_not_logged_in">Not logged in</string>
     <string name="aa_launch_native">Native mode</string>
-    <string name="aa_driving_optimized_change">Use Home Assistant in drive mode?</string>
+    <string name="aa_driving_optimized_change">Use the full Home Assistant interface?</string>
     <string name="aa_navigation">Navigation</string>
     <string name="aa_no_entities_with_locations">No entities with locations found</string>
     <string name="aa_change_server">Change server</string>
@@ -1277,9 +1277,9 @@
     <string name="sensor_description_car_fuel_type">List of available fuel types for the connected car</string>
     <string name="basic_sensor_name_car_ev_connector_type">Car EV connector type</string>
     <string name="sensor_description_car_ev_connector_type">List of available EV connectors for the connected car</string>
-    <string name="aa_set_favorites">Select your favorite entities to appear in the favorites category in the Home Assistant driving interface. You can also drag and drop to change the order in which they appear. Keep in mind that the amount of entities shown will vary from vehicle to vehicle.</string>
+    <string name="aa_set_favorites">Select your favorite entities to appear in the favorites category. You can also drag and drop to change the order in which they appear. Keep in mind that the amount of entities shown will vary from vehicle to vehicle.</string>
     <string name="aa_favorites">Android Auto favorites</string>
-    <string name="aa_favorites_summary">Select your favorite entities to be shown in the app while viewing the Home Assistant driving interface</string>
+    <string name="aa_favorites_summary">Select your favorite entities to be shown in the app interface</string>
     <string name="android_automotive">Android Automotive</string>
     <string name="android_automotive_favorites">Driving favorites</string>
     <string name="alarm_control_panels">Alarm Control Panels</string>


### PR DESCRIPTION
## Summary
- reword Android Auto prompts to reflect unrestricted behavior
- drop drive-mode references in favorites setup summary

## Testing
- `./gradlew :common:lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e226e7f3c8325ab686b3a17b5f443