### PR TITLE
Fix absolute URL handling after navigate prefix

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -51,7 +51,7 @@ object UrlUtil {
             asURI == null -> {
                 base
             }
-            isAbsoluteUrl(input) -> {
+            isAbsoluteUrl(asURI.toString()) -> {
                 asURI.toURL()
             }
             else -> { // Input is relative to base URL

--- a/common/src/test/kotlin/io/homeassistant/companion/android/util/UrlUtilTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/util/UrlUtilTest.kt
@@ -1,0 +1,18 @@
+package io.homeassistant.companion.android.util
+
+import java.net.URL
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UrlUtilTest {
+    @Test
+    fun `handle should return absolute url when navigate prefix present`() {
+        val base = URL("https://base.example")
+        val input = "homeassistant://navigate/https://www.example.com/path"
+        val expected = URL("https://www.example.com/path")
+
+        val result = UrlUtil.handle(base, input)
+
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
## Summary
- fix absolute URL detection when using `homeassistant://navigate/`
- add unit test covering absolute navigate URLs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2060fd18832598eb42c57237eb2f